### PR TITLE
fix: rename functions with reserved words

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,11 @@
   "main": "",
   "typings": "./index.d.ts",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "tsc index.d.ts --lib es2015"
   },
   "author": "Hap-Team",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^3.8.3"
+  }
 }

--- a/system/file.d.ts
+++ b/system/file.d.ts
@@ -161,7 +161,7 @@ declare module '@system.file' {
      * 删除本地存储的文件，接口中使用的 URI 描述请参考文件组织
      * @param obj
      */
-    export function delete (obj: {
+    function _delete (obj: {
         /**
          * 需要删除的文件 uri，不能是应用资源路径和 tmp 类型的 uri
          */
@@ -181,6 +181,7 @@ declare module '@system.file' {
              */
             complete ?: () => void
     }): void
+    export { _delete as delete }
 
     /**
      * 写文本到文件

--- a/system/storage.d.ts
+++ b/system/storage.d.ts
@@ -85,7 +85,7 @@ declare module '@system.storage' {
      * 删除存储内容
      * @param obj
      */
-    export function delete(obj: {
+    export function _delete(obj: {
         /**
          * 索引
          */
@@ -103,6 +103,7 @@ declare module '@system.storage' {
          */
         complete?: () => void
     }): void
+    export { _delete as delete }
 
     /**
      * 返回存储中某个index的键名


### PR DESCRIPTION
error TS1359: Identifier expected. 'delete' is a reserved word that cannot be used here.